### PR TITLE
Vagrant config for minimalistic CRM boxes

### DIFF
--- a/uplift-vagrant/.build-helpers.ps1
+++ b/uplift-vagrant/.build-helpers.ps1
@@ -57,3 +57,119 @@ function Confirm-ExitCode($code, $message)
         throw  $errorMessage
     }
 }
+
+
+function Get-ToolCmd($name) {
+    return (Get-Command $name -ErrorAction SilentlyContinue)
+}
+
+Function Test-PortInUse
+{
+    Param(
+        [Parameter(Mandatory=$true)]
+        [Int] $port
+    )
+
+    $socket = New-Object System.Net.Sockets.TcpClient
+
+    try
+    {
+        $socket.BeginConnect("127.0.0.1", $port, $null, $null) | Out-Null
+        # $success = $connect.AsyncWaitHandle.WaitOne(500, $true)
+
+        if ($socket.Connected)
+        {
+            return $True
+        }
+
+        return $False
+    } finally {
+        if($null -ne $socket) {
+            $socket.Close()
+            $socket.Dispose()
+            $socket = $null
+        }
+    }
+}
+
+Function Get-RandomPort
+{
+    return Get-Random -Min 8000 -Max 9000
+}
+
+Function Get-RandomUsablePort
+{
+    Param(
+        [Int] $maxTries = 100
+    );
+    $result = -1;
+    $tries = 0;
+    DO
+    {
+        $randomPort = Get-RandomPort;
+        if (-Not (Test-PortInUse($randomPort)))
+        {
+            $result = $randomPort;
+        }
+        $tries += 1;
+    } While (($result -lt 0) -and ($tries -lt $maxTries));
+    return $result;
+}
+
+
+function Test-HttpUrl($url) {
+
+    Write-BuildInfoMessage "[~] checking url: $url"
+    
+    $result = Invoke-WebRequest "$url" `
+        -UseBasicParsing `
+        -DisableKeepAlive `
+        -Method HEAD 
+
+    if($result.StatusCode -eq 200) {
+        Write-BuildInfoMessage  "[+] StatusCode: $($result.StatusCode) for url: $url"
+    } else {
+        throw "[!] StatusCode: $($result.StatusCode), expected 200!"
+    }
+}
+
+function Start-LocalHttpServer {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Scope="Function")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "", Scope="Function")]
+
+    param(
+        $port,
+        $path
+    )
+
+    Write-BuildInfoMessage "[~] Starting http-server to serve packer/vagrant builds"
+    Write-BuildInfoMessage " - port : $port"
+    Write-BuildInfoMessage " - local: localhost:$port"
+    Write-BuildInfoMessage " - vm   : 10.0.2.2:$port"
+    Write-BuildInfoMessage " - path : $path"
+
+    if( (Test-Path $path) -eq $False) {
+        $errorMessage = " [!] Path does not exist: $path"
+
+        Write-BuildErrorMessage $errorMessage
+        throw $errorMessage
+    }
+
+    $httpServerTool = Get-ToolCmd("http-server") 
+
+    if($null -eq $httpServerTool) {
+        $errMessage = "http-server tool is not here. Use 'npm install http-server -g' to install it - https://www.npmjs.com/package/http-server"
+        
+        Write-BuildErrorMessage $errMessage
+        throw $errMessage
+    }
+
+    $job = http-server $path -p $port &
+
+    Write-BuildInfoMessage "Pause 5 sec allowing http-server to start..."
+    Start-Sleep 5
+
+    Test-HttpUrl "http://localhost:$port"
+
+    return $job
+}

--- a/uplift-vagrant/.build.ps1
+++ b/uplift-vagrant/.build.ps1
@@ -1,16 +1,35 @@
-
-
-
 param(
     $vagrantFolder = "sp16lts-dev",
     
     $UPLF_VAGRANT_BOX_NAME = $null,
-    $UPLF_VBMANAGE_MACHINEFOLDER = $null
+    $UPLF_VBMANAGE_MACHINEFOLDER = $null,
+
+    $UPLF_HTTP_DIRECTORY = $null
 )
 
 $dirPath = $BuildRoot
 
 . "$dirPath/.build-helpers.ps1"
+
+
+Enter-Build {
+
+    $httpDirectoryPath = $UPLF_HTTP_DIRECTORY
+    if( $null -eq $httpDirectoryPath ) { $httpDirectoryPath = $env:UPLF_HTTP_DIRECTORY }
+
+    if( $null -ne $httpDirectoryPath ) {
+        Write-BuildInfoMessage "Starring local http server: $httpDirectoryPath"
+
+        $port = Get-RandomUsablePort
+        $httpServerJob  = Start-LocalHttpServer $port $httpDirectoryPath
+
+        $binAddress = ("10.0.2.2:" +  $port )
+        Write-BuildInfoMessage "Setting UPLF_BIN_REPO_HTTP_ADDR: $binAddress"
+        $ENV:UPLF_BIN_REPO_HTTP_ADDR = $binAddress
+    } else {
+        Write-BuildInfoMessage "Skipping local http server"
+    }    
+}
 
 # Synopsis: Tests newly created vagrant box
 task VagrantBoxTest {

--- a/uplift-vagrant/crm-dev/.vagrant-cleanup.ps1
+++ b/uplift-vagrant/crm-dev/.vagrant-cleanup.ps1
@@ -1,0 +1,1 @@
+# vagrant destroy -f

--- a/uplift-vagrant/crm-dev/.vagrant-cleanup.ps1
+++ b/uplift-vagrant/crm-dev/.vagrant-cleanup.ps1
@@ -1,1 +1,1 @@
-# vagrant destroy -f
+vagrant destroy -f

--- a/uplift-vagrant/crm-dev/.vagrant-test.ps1
+++ b/uplift-vagrant/crm-dev/.vagrant-test.ps1
@@ -1,0 +1,7 @@
+Write-Host "vagrant testing: vagrant up"
+vagrant up 
+if ($LASTEXITCODE -ne 0 ) { throw "Fail!" }
+
+Write-Host "vagrant testing: vagrant reload --provision"
+vagrant reload  --provision
+if ($LASTEXITCODE -ne 0 ) { throw "Fail!" }

--- a/uplift-vagrant/crm-dev/Vagrantfile
+++ b/uplift-vagrant/crm-dev/Vagrantfile
@@ -1,0 +1,295 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'net/http'
+
+Vagrant.require_version ">= 2.2.3"
+
+# boxes for dc and crm dev VMs
+box_name            = ENV['UPLF_VAGRANT_BOX_NAME']     || "SubPointSolutions/win-2016-datacenter-soe-latest" 
+crm_box_name        = ENV['UPLF_VAGRANT_CRM_BOX_NAME'] || "SubPointSolutions/win-2016-datacenter-app-sql16-sp2" 
+
+# other flags
+linked_clone        = ENV['UPLF_VAGRANT_LINKED_CLONE'].to_s.empty? == false
+machine_folder      = ENV['UPLF_VBMANAGE_MACHINEFOLDER'] || nil
+
+# CRM relates settings: box, license key and local http-server address
+crm_resource_name   = ENV['UPLF_CRM_RESOURCE_NAME']  || "ms-dynamics-crm90-server-en"
+crm_license_key     = ENV['UPLF_CRM_LICENSE']        || "KKNV2-4YYK8-D8HWD-GDRMW-29YTW"
+http_server_address = ENV['UPLF_BIN_REPO_HTTP_ADDR'] || 'http://10.0.2.2:8080'
+
+puts "Using http-server on: #{http_server_address}"
+
+# minimal CRM install
+# incluenced by: 
+# https://github.com/shurick81/vm-devops-starter
+# https://github.com/shurick81/Dynamics365Configuration
+
+# two vm topology: dc and client 
+# - dc box gets promoted to minimal domain controller
+# - client box gets SQL server completion and then setups minimal CRM instance
+
+# CRM better have 6 Gb RAM, owervise our of RAM exception might be raised by the installed
+
+vm_dc     = "dc"
+vm_client = "crm"
+
+# this configuration is driven by the ENV variables
+# use the following variables to change default RAM/CPU allocation
+# 
+# UPLF_DC_MEMORY      / UPLF_DC_CPUS 
+# UPLF_SP16LTS_MEMORY / UPLF_SP16LTS_CPUS 
+
+# uplift helper for vagrant configurations
+uplift = VagrantPlugins::Uplift::Config()
+
+# network range where dc and other vms will be created
+# by default 192.168.4.*, use as following or skip it
+# be aware that two dc won't get along within the same network
+# use different networks for different stacks or one stack at a time
+uplift.set_network_range("192.168.16")
+
+Vagrant.configure("2") do |config|
+  
+  # additional plugins to be used with this vagrant config
+  config.vagrant.plugins = [
+    "vagrant-reload",
+    "vagrant-uplift"
+  ]
+
+  # domain controller box
+  config.vm.define(vm_dc) do | vm_config |      
+
+    # -- UPLIFT CONFIG START --
+    # there should not be a need to modify core uplift configration
+    # avoid making changes to it, add your own provision at the end
+
+    vm_config.vm.box = box_name
+
+    # standard config
+    uplift.set_default_synced_folder(vm_dc, vm_config)
+    uplift.set_2Gb(vm_dc, vm_config)
+    uplift.set_hostname(vm_dc, vm_config, vm_dc)
+    
+    # always setup correct networking
+    uplift.set_private_dc_network(vm_dc, vm_config)
+    
+    # uplift baseline
+    if !uplift.has_checkpoint?(vm_dc, 'dsc-soe') 
+      uplift.provision_win16_dsc_soe(vm_dc, vm_config)
+      vm_config.vm.provision :uplift_checkpoint, name: 'dsc-soe'
+    end
+
+    # uplift dc creation
+    if !uplift.has_checkpoint?(vm_dc, 'dc-creation') 
+      uplift.provision_dc16(vm_dc, vm_config)
+      vm_config.vm.provision :uplift_checkpoint, name: 'dc-creation'
+    end
+
+    if !uplift.has_checkpoint?(vm_dc, 'dsc-shortcuts') 
+      uplift.provision_win16_dsc_shortcuts(vm_dc, vm_config)
+      vm_config.vm.provision :uplift_checkpoint, name: 'dsc-shortcuts'
+    end
+
+    # additional virtualbox tweaks
+    vm_config.vm.provider "virtualbox" do |v|
+      v.gui  = false
+     
+      v.cpus   = uplift.get_vm_cpus(vm_dc, 4)
+      v.memory = uplift.get_vm_memory(vm_dc, 2 * 1024)
+
+      v.customize ['modifyvm', :id, '--cpuexecutioncap', '100'] 
+      v.customize ["modifyvm", :id, "--ioapic", "on"]
+
+      v.linked_clone = linked_clone
+    end
+
+    # -- UPLIFT CONFIG END --
+    # add your custom vagrant configuration here
+
+    if !uplift.has_checkpoint?(vm_dc, 'crm-ps-modules') 
+      vm_config.vm.provision "shell",
+        name: "crm-ps-modules",
+        path: "scripts-dc/crm-ps-modules.ps1"
+
+      vm_config.vm.provision :uplift_checkpoint, name: 'crm-ps-modules'
+    end
+
+    if !uplift.has_checkpoint?(vm_dc, "crm-domain-users") 
+      vm_config.vm.provision "shell",
+        name: "crm-domain-users",
+        path: "scripts-dc/crm-domain-users.ps1"
+
+      vm_config.vm.provision :uplift_checkpoint, name: "crm-domain-users"
+    end
+
+  end  
+
+  # dev box - sq; + crm with minimal web sites
+  config.vm.define(vm_client) do | vm_config |   
+  
+    # -- UPLIFT CONFIG START --
+    # there should not be a need to modify core uplift configration
+    # avoid making changes to it, add your own provision at the end
+
+    # box config
+    vm_config.vm.box = crm_box_name
+    vm_config.vm.box_check_update = false
+
+    # uplift - base config
+    uplift.set_default_synced_folder(vm_client, vm_config)
+    uplift.set_4Gb(vm_client, vm_config)
+    uplift.set_hostname(vm_client, vm_config, vm_client)   
+
+    # uplift - network, base provision + dc join
+    uplift.set_client_network(vm_client, vm_config, vm_client)
+    # uplift.set_public_network(vm_client, vm_config, vm_client_public_ip)
+
+    if !uplift.has_checkpoint?(vm_client, 'dsc-soe') 
+      uplift.provision_win16_dsc_soe(vm_client, vm_config)
+      vm_config.vm.provision :uplift_checkpoint, name: 'dsc-soe'
+    end
+
+    if !uplift.has_checkpoint?(vm_client, 'dc-join') 
+      uplift.provision_dc_join(vm_client, vm_config)
+      vm_config.vm.provision :uplift_checkpoint, name: 'dc-join'
+    end
+
+    if !uplift.has_checkpoint?(vm_client, 'dsc-shortcuts') 
+      uplift.provision_win16_dsc_shortcuts(vm_client, vm_config)
+      vm_config.vm.provision :uplift_checkpoint, name: 'dsc-shortcuts'
+    end
+
+    # complete sql image
+    if !uplift.has_checkpoint?(vm_client, 'sql-complete-image') 
+        uplift.provision_sql16_complete_image(vm_client, vm_config)
+        vm_config.vm.provision :uplift_checkpoint, name: 'sql-complete-image'
+    end
+
+    if !uplift.has_checkpoint?(vm_client, 'sql-optimize') 
+      #uplift.provision_sql16_optimize(vm_client, vm_config, max_memory: 6 * 1024)
+      uplift.provision_sql16_optimize(vm_client, vm_config)
+      vm_config.vm.provision :uplift_checkpoint, name: 'sql-optimize'
+    end
+
+    # virtualbox tuning
+    vm_config.vm.provider "virtualbox" do |v|
+      v.gui  = false
+      
+      v.cpus   = uplift.get_vm_cpus(vm_client, 4)
+      v.memory = uplift.get_vm_memory(vm_client, 6 * 1024)
+
+      v.customize ['modifyvm', :id, '--cpuexecutioncap', '100'] 
+      v.customize ["modifyvm", :id, "--ioapic", "on"]
+
+      v.linked_clone = linked_clone
+    end
+
+    # -- UPLIFT CONFIG END --
+
+    # CRM specific provisoin
+
+    # provision additional powershell modules
+    if !uplift.has_checkpoint?(vm_client, "crm-ps-modules") 
+      vm_config.vm.provision "shell",
+        name: "crm-ps-modules",
+        path: "scripts-crm/crm-ps-modules.ps1"
+
+      vm_config.vm.provision :uplift_checkpoint, name: "crm-ps-modules"
+    end
+
+    # cred-ssp setup
+    if !uplift.has_checkpoint?(vm_client, "crm-cred-ssp") 
+      vm_config.vm.provision "shell",
+        name: "crm-cred-ssp",
+        path: "scripts-crm/cred-ssp.ps1"
+
+      vm_config.vm.provision :reload
+
+      vm_config.vm.provision :uplift_checkpoint, name: "crm-cred-ssp"
+    end
+
+    # local admin setup
+    if !uplift.has_checkpoint?(vm_client, "crm-local-admin-group") 
+      vm_config.vm.provision "shell",
+        name: "crm-local-admin-group",
+        path: "scripts-crm/crm-domain-client-group.ps1"
+
+      vm_config.vm.provision :uplift_checkpoint, name: "crm-local-admin-group"
+    end
+
+    # self-signed certn
+    if !uplift.has_checkpoint?(vm_client, "crm-ssl-self-signed-cert") 
+      vm_config.vm.provision "shell",
+        name: "crm-ssl-self-signed-cert",
+        path: "scripts-crm/crm-ssl-self-signed-cert.ps1"
+
+      vm_config.vm.provision :uplift_checkpoint, name: "crm-ssl-self-signed-cert"
+    end
+
+    # sql rs config
+    if !uplift.has_checkpoint?(vm_client, "sql-rs-config") 
+      vm_config.vm.provision "shell",
+        name: "sql-rs-config",
+        path: "scripts-crm/sql-rs-config.ps1"
+
+      vm_config.vm.provision :uplift_checkpoint, name: "sql-rs-config"
+    end
+
+    # crm sql users
+    if !uplift.has_checkpoint?(vm_client, "crm-sql-accounts") 
+      vm_config.vm.provision "shell",
+        name: "crm-sql-accounts",
+        path: "scripts-crm/crm-sql-accounts.dsc.ps1"
+
+      vm_config.vm.provision :uplift_checkpoint, name: "crm-sql-accounts"
+    end
+
+    # crm installation media
+    if !uplift.has_checkpoint?(vm_client, "crm-install-media") 
+      vm_config.vm.provision "shell",
+        name: "crm-install-media",
+        path: "scripts-crm/crm-dynamics-download.ps1",
+        env: {
+          "UPLF_CRM_RESOURCE_NAME" => crm_resource_name,
+          "UPLF_HTTP_ADDR" => http_server_address
+        }
+
+      vm_config.vm.provision :uplift_checkpoint, name: "crm-install-media"
+    end
+
+    # crm install
+    if !uplift.has_checkpoint?(vm_client, "crm-install-provision") 
+      vm_config.vm.provision "shell",
+        name: "crm-install-provision",
+        path: "scripts-crm/crm-dynamics-provision.ps1",
+        env: {
+          "UPLF_CRM_RESOURCE_NAME" => crm_resource_name,
+          "UPLF_HTTP_ADDR" => http_server_address,
+          "UPLF_CRM_LICENCE_KEY" => crm_license_key
+        }
+
+      vm_config.vm.provision :uplift_checkpoint, name: "crm-install-provision"
+    end
+
+    # crm web sites
+    if !uplift.has_checkpoint?(vm_client, "crm-default-webs") 
+      vm_config.vm.provision "shell",
+        name: "crm-default-webs",
+        path: "scripts-crm/crm-dynamics-default-webs.ps1"
+
+      vm_config.vm.provision :uplift_checkpoint, name: "crm-default-webs"
+    end
+
+    # crm web shortcuts
+    if !uplift.has_checkpoint?(vm_client, "crm-default-webs-shortcuts") 
+      vm_config.vm.provision "shell",
+        name: "crm-default-webs-shortcuts",
+        path: "scripts-crm/crm-dynamics-default-webs-shortcuts.dsc.ps1"
+
+      vm_config.vm.provision :uplift_checkpoint, name: "crm-default-webs-shortcuts"
+    end
+   
+  end 
+  
+end

--- a/uplift-vagrant/crm-dev/scripts-crm/cred-ssp.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/cred-ssp.ps1
@@ -1,0 +1,61 @@
+# fail on errors and include uplift helpers
+$ErrorActionPreference = "Stop"
+
+Import-Module Uplift.Core
+
+Write-UpliftMessage "[~] Installing CRM specific image settings"
+Write-UpliftEnv
+
+# CRM provision needs more RAM 
+# our of ram exception might be raised over  a long provision session 
+Write-UpliftMessage '[~] Reconfiguring WinRM settings, MaxMemoryPerShellMB="0"'
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="0"}'
+
+Configuration CRM_ImageConfiguration
+{
+    Import-DscResource -ModuleName PSDesiredStateConfiguration
+    Import-DscResource -ModuleName xCredSSP -ModuleVersion 1.3.0.0
+
+    Node "localhost"
+    {
+        LocalConfigurationManager
+        {
+            ConfigurationMode = 'ApplyOnly'
+            RebootNodeIfNeeded = $false
+            RefreshMode = "Push"
+        }
+
+        xCredSSP CredSSPServer
+        {
+            Ensure  = "Present"
+            Role    = "Server"
+        }
+
+
+        xCredSSP CredSSPClient
+        {
+            Ensure = "Present"
+            Role = "Client"
+            DelegateComputers = "*"
+        }
+    }
+}
+
+$config = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+
+            PSDscAllowDomainUser        = $true
+            PSDscAllowPlainTextPassword = $true
+
+            RetryCount = 10
+            RetryIntervalSec = 30
+        }
+    )
+}
+
+$configuration = Get-Command CRM_ImageConfiguration
+Start-UpliftDSCConfiguration $configuration $config $False
+
+exit 0

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-domain-client-group.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-domain-client-group.ps1
@@ -25,6 +25,20 @@ Configuration Configure_CRMLocalAdminGroup {
                 "uplift\_ssrs"
             )
         }
+
+        # The account specified to run the Dynamics 365 application does not have Performance Counter permissions.
+        Group PerformanceLogUsers
+        {
+            GroupName  = "Performance Log Users"
+            MembersToInclude    = @(
+                "uplift\CRM01PrivUserGroup",
+                "uplift\_crmasync",
+                "uplift\_crmsrv",
+                "uplift\_crmdplsrv",
+                "uplift\_ssrs"
+            )
+        }
+        
     }
 }
 

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-domain-client-group.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-domain-client-group.ps1
@@ -1,0 +1,45 @@
+# fail on errors and include uplift helpers
+$ErrorActionPreference = "Stop"
+
+Import-Module Uplift.Core
+
+Write-UpliftMessage "Configuring CRM local admin group..."
+Write-UpliftEnv
+
+Configuration Configure_CRMLocalAdminGroup {
+    
+    Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
+    
+    Node localhost
+    {
+        Group AdminGroup
+        {
+            GroupName           = "Administrators"
+            # vagrant:vagrant should have access, no Credential needed
+            # Credential          = $DomainAdminCredential
+            MembersToInclude    = @(
+                "uplift\CRM01PrivUserGroup",
+                "uplift\_crmasync",
+                "uplift\_crmsrv",
+                "uplift\_crmdplsrv",
+                "uplift\_ssrs"
+            )
+        }
+    }
+}
+
+$config = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+            PSDscAllowPlainTextPassword = $true
+            RetryCount = 10
+            RetryIntervalSec = 30
+        }
+    )
+}
+
+$configuration = Get-Command Configure_CRMLocalAdminGroup
+Start-UpliftDSCConfiguration $configuration $config $True
+
+exit 0

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-default-webs-shortcuts.dsc.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-default-webs-shortcuts.dsc.ps1
@@ -1,0 +1,32 @@
+# fail on errors and include uplift helpers
+$ErrorActionPreference = "Stop"
+
+Import-Module Uplift.Core
+
+Write-UpliftMessage "Running CRM Shortcuts..."
+
+Configuration CRM_Shortcuts
+{
+    Import-DscResource -ModuleName DSCR_Shortcut -ModuleVersion '1.3.7'
+
+    $desktopPath = [Environment]::GetFolderPath("CommonDesktopDirectory")
+
+    cShortcut Crm_Web_Http
+    {
+        Path      = "$desktopPath\CRM HTTPS.lnk"
+        Target    = "C:\Program Files\Internet Explorer\iexplore.exe"
+        Arguments = 'https://crm.uplift.local'
+    }
+
+    cShortcut Crm_Web_Https
+    {
+        Path      = "$desktopPath\CRM HTTP.lnk"
+        Target    = "C:\Program Files\Internet Explorer\iexplore.exe"
+        Arguments = 'http://crm.uplift.local:5555'
+    }
+}
+
+$configuration = Get-Command CRM_Shortcuts
+Start-UpliftDSCConfiguration $configuration $config -ExpectInDesiredState $True
+
+exit 0

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-default-webs.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-default-webs.ps1
@@ -1,0 +1,102 @@
+
+# fail on errors and include uplift helpers
+$ErrorActionPreference = "Stop"
+
+Import-Module Uplift.Core
+
+Write-UpliftMessage "Configuring CRM Default Web Site: 443 and 5555"
+Write-UpliftEnv
+
+Configuration CRMDefaultWebs
+{
+    Import-DscResource -ModuleName PSDesiredStateConfiguration
+    
+    Import-DscResource -ModuleName CertificateDsc -ModuleVersion 4.1.0.0
+    Import-DscResource -ModuleName xWebAdministration -ModuleVersion 1.19.0.0
+    Import-DSCResource -Module xSystemSecurity -Name xIEEsc -ModuleVersion 1.4.0.0
+
+    Node localhost
+    {
+        $securedPassword = ConvertTo-SecureString "c0mp1Expa~~" -AsPlainText -Force
+        $CRMInstallAccountCredential = New-Object System.Management.Automation.PSCredential( "uplift\_crmadmin", $securedPassword );
+
+        $pfxPassword = "asd94y3475n";
+        $securedPassword = ConvertTo-SecureString $pfxPassword -AsPlainText -Force
+        $pfxCredential = New-Object System.Management.Automation.PSCredential( "fake", $securedPassword )
+
+        $hostName = "$env:COMPUTERNAME.uplift.local";
+        $pfxPath = "c:\certs\$hostName.pfx";
+        $cerPath = "c:\certs\$hostName.cer";
+        
+        $pfx = New-Object -TypeName "System.Security.Cryptography.X509Certificates.X509Certificate2";
+        $pfx.Import($pfxPath,$pfxPassword,[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet);
+
+        PfxImport crmhost
+        {
+            Thumbprint  = $pfx.thumbprint
+            Path        = $pfxPath
+            Location    = 'LocalMachine'
+            Store       = 'My'
+            Credential  = $pfxCredential
+        }
+
+        CertificateExport crmhost
+        {
+            Type        = 'CERT'
+            Thumbprint  = $pfx.thumbprint
+            Path        = $cerPath
+            DependsOn   = "[PfxImport]crmhost"
+        }
+
+        CertificateImport crmhost
+        {
+            Thumbprint  = $pfx.thumbprint
+            Location    = 'LocalMachine'
+            Store       = 'Root'
+            Path        = $cerPath
+            DependsOn   = "[CertificateExport]crmhost"
+        }
+
+        xWebsite WA01Site
+        {
+            Name        = "Microsoft Dynamics CRM"
+            State       = "Started"
+            BindingInfo = @(
+                MSFT_xWebBindingInformation {
+                    Protocol = "HTTP"
+                    Port = 5555
+                }
+                MSFT_xWebBindingInformation {
+                    Protocol = "HTTPS"
+                    Port = 443
+                    CertificateThumbprint = $pfx.thumbprint
+                    CertificateStoreName = "My"
+                    HostName = "$env:COMPUTERNAME.uplift.local"
+                    SslFlags = 1
+                }
+            )
+        }
+
+        Registry CrmLocalZone
+        {
+            Ensure                  = "Present"
+            Key                     = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap\Domains\$env:COMPUTERNAME.uplift.local"
+            ValueName               = "https"
+            ValueType               = "DWord"
+            ValueData               = "1"
+            PsDscRunAsCredential    = $CRMInstallAccountCredential
+        }
+
+        xIEEsc DisableIEEsc
+        {
+            IsEnabled   = $false;
+            UserRole    = "Administrators"
+        }
+
+    }
+}
+
+$configuration = Get-Command CRMDefaultWebs
+Start-UpliftDSCConfiguration $configuration $config -ExpectInDesiredState $True
+
+exit 0

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-download.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-download.ps1
@@ -10,6 +10,12 @@ $resourceName = Get-UpliftEnvVariable "UPLF_CRM_RESOURCE_NAME" "" "ms-dynamics-c
 $serverUrl    = Get-UpliftEnvVariable "UPLF_HTTP_ADDR"
 $uplifLocalRepository =  Get-UpliftEnvVariable "UPLF_LOCAL_REPOSITORY_PATH" "" "c:/_uplift_resources"
 
+# always turn into http, it might be 10.0.2.2 address only
+# uplift needs explicit http/https only
+if($serverUrl.ToLower().StartsWith("http") -eq $False) {
+    $serverUrl = "http://" + $serverUrl
+}
+
 Write-UpliftMessage "Downloading resource: $resourceName"
 pwsh -c Invoke-Uplift resource download-local $resourceName -server $serverUrl -repository $uplifLocalRepository
 

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-download.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-download.ps1
@@ -8,6 +8,7 @@ Write-UpliftEnv
 
 $resourceName = Get-UpliftEnvVariable "UPLF_CRM_RESOURCE_NAME" "" "ms-dynamics-crm90-server-en"
 $serverUrl    = Get-UpliftEnvVariable "UPLF_HTTP_ADDR"
+
 $uplifLocalRepository =  Get-UpliftEnvVariable "UPLF_LOCAL_REPOSITORY_PATH" "" "c:/_uplift_resources"
 
 # always turn into http, it might be 10.0.2.2 address only
@@ -21,8 +22,10 @@ pwsh -c Invoke-Uplift resource download-local $resourceName -server $serverUrl -
 
 Write-UpliftMessage "Unpacking resource: $resourceName"
 
-$filePath = "C:\_uplift_resources\$resourceName\latest\CRM9.0-Server-ENU-amd64.exe"
-$directoryPath =  "C:\_uplift_resources\$resourceName\latest\unpacked"
+$resourceLatestFolder = "$uplifLocalRepository\$resourceName\latest"
+$filePath = Find-UpliftFileInPath $resourceLatestFolder
+
+$directoryPath =  "$uplifLocalRepository\$resourceName\latest\unpacked"
 
 Start-Process -FilePath $filePath -ArgumentList "/extract:$directoryPath /passive /quiet" -Wait -NoNewWindow
 

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-download.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-download.ps1
@@ -1,0 +1,23 @@
+# fail on errors and include uplift helpers
+$ErrorActionPreference = "Stop"
+
+Import-Module Uplift.Core
+
+Write-UpliftMessage "Downloading CRM resource..."
+Write-UpliftEnv
+
+$resourceName = Get-UpliftEnvVariable "UPLF_CRM_RESOURCE_NAME" "" "ms-dynamics-crm90-server-en"
+$serverUrl    = Get-UpliftEnvVariable "UPLF_HTTP_ADDR"
+$uplifLocalRepository =  Get-UpliftEnvVariable "UPLF_LOCAL_REPOSITORY_PATH" "" "c:/_uplift_resources"
+
+Write-UpliftMessage "Downloading resource: $resourceName"
+pwsh -c Invoke-Uplift resource download-local $resourceName -server $serverUrl -repository $uplifLocalRepository
+
+Write-UpliftMessage "Unpacking resource: $resourceName"
+
+$filePath = "C:\_uplift_resources\$resourceName\latest\CRM9.0-Server-ENU-amd64.exe"
+$directoryPath =  "C:\_uplift_resources\$resourceName\latest\unpacked"
+
+Start-Process -FilePath $filePath -ArgumentList "/extract:$directoryPath /passive /quiet" -Wait -NoNewWindow
+
+exit 0

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-provision.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-provision.ps1
@@ -1,0 +1,54 @@
+# fail on errors and include uplift helpers
+$ErrorActionPreference = "Stop"
+
+Import-Module Uplift.Core
+
+Write-UpliftMessage "Running CRM privision..."
+Write-UpliftEnv
+
+$dbHostName      = $env:COMPUTERNAME
+$computerName    = ($env:COMPUTERNAME).Split('.')[0]
+
+$resourceName    = Get-UpliftEnvVariable "UPLF_CRM_RESOURCE_NAME" "" "ms-dynamics-crm90-server-en"
+$mediaDir        = "C:\_uplift_resources\$resourceName\latest\unpacked"
+$licenceKey      = Get-UpliftEnvVariable "UPLF_CRM_LICENCE_KEY" "" "KKNV2-4YYK8-D8HWD-GDRMW-29YTW"
+
+$securedPassword = ConvertTo-SecureString "c0mp1Expa~~" -AsPlainText -Force
+
+$CRMInstallAccountCredential        = New-Object System.Management.Automation.PSCredential( "uplift\_crmadmin", $securedPassword );
+$CRMServiceAccountCredential        = New-Object System.Management.Automation.PSCredential( "uplift\_crmsrv", $securedPassword );
+$DeploymentServiceAccountCredential = New-Object System.Management.Automation.PSCredential( "uplift\_crmdplsrv", $securedPassword );
+$SandboxServiceAccountCredential    = New-Object System.Management.Automation.PSCredential( "uplift\_crmsandbox", $securedPassword );
+$VSSWriterServiceAccountCredential  = New-Object System.Management.Automation.PSCredential( "uplift\_crmvsswrit", $securedPassword );
+$AsyncServiceAccountCredential      = New-Object System.Management.Automation.PSCredential( "uplift\_crmasync", $securedPassword );
+$MonitoringServiceAccountCredential = New-Object System.Management.Automation.PSCredential( "uplift\_crmmon", $securedPassword );
+
+Install-Dynamics365Server `
+    -MediaDir $mediaDir `
+    -LicenseKey $licenceKey `
+    -InstallDir "c:\Program Files\Microsoft Dynamics CRM" `
+    -CreateDatabase `
+    -SqlServer $dbHostName `
+    -PrivUserGroup "CN=CRM01PrivUserGroup,OU=CRM groups,DC=uplift,DC=local" `
+    -SQLAccessGroup "CN=CRM01SQLAccessGroup,OU=CRM groups,DC=uplift,DC=local" `
+    -UserGroup "CN=CRM01UserGroup,OU=CRM groups,DC=uplift,DC=local" `
+    -ReportingGroup "CN=CRM01ReportingGroup,OU=CRM groups,DC=uplift,DC=local" `
+    -PrivReportingGroup "CN=CRM01PrivReportingGroup,OU=CRM groups,DC=uplift,DC=local" `
+    -CrmServiceAccount $CRMServiceAccountCredential `
+    -DeploymentServiceAccount $DeploymentServiceAccountCredential `
+    -SandboxServiceAccount $SandboxServiceAccountCredential `
+    -VSSWriterServiceAccount $VSSWriterServiceAccountCredential `
+    -AsyncServiceAccount $AsyncServiceAccountCredential `
+    -MonitoringServiceAccount $MonitoringServiceAccountCredential `
+    -CreateWebSite `
+    -WebSitePort 5555 `
+    -WebSiteUrl "https://$computerName.uplift.local" `
+    -Organization "Uplift Ltd." `
+    -OrganizationUniqueName uplift `
+    -BaseISOCurrencyCode USD `
+    -BaseCurrencyName "US Dollar" `
+    -BaseCurrencySymbol `$ `
+    -BaseCurrencyPrecision 2 `
+    -OrganizationCollation Latin1_General_CI_AI `
+    -ReportingUrl ("http://" + $computerName + ":80/ReportServer") `
+    -InstallAccount $CRMInstallAccountCredential

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-provision.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-dynamics-provision.ps1
@@ -6,6 +6,11 @@ Import-Module Uplift.Core
 Write-UpliftMessage "Running CRM privision..."
 Write-UpliftEnv
 
+$crmModuleVersion  = (Get-InstalledModule Dynamics365Configuration).Version
+$pullLogMinVersion = "1.0.0.0"
+
+Write-UpliftMessage "CRM module version: Dynamics365Configuration $crmModuleVersion"
+
 $dbHostName      = $env:COMPUTERNAME
 $computerName    = ($env:COMPUTERNAME).Split('.')[0]
 
@@ -23,32 +28,71 @@ $VSSWriterServiceAccountCredential  = New-Object System.Management.Automation.PS
 $AsyncServiceAccountCredential      = New-Object System.Management.Automation.PSCredential( "uplift\_crmasync", $securedPassword );
 $MonitoringServiceAccountCredential = New-Object System.Management.Automation.PSCredential( "uplift\_crmmon", $securedPassword );
 
-Install-Dynamics365Server `
-    -MediaDir $mediaDir `
-    -LicenseKey $licenceKey `
-    -InstallDir "c:\Program Files\Microsoft Dynamics CRM" `
-    -CreateDatabase `
-    -SqlServer $dbHostName `
-    -PrivUserGroup "CN=CRM01PrivUserGroup,OU=CRM groups,DC=uplift,DC=local" `
-    -SQLAccessGroup "CN=CRM01SQLAccessGroup,OU=CRM groups,DC=uplift,DC=local" `
-    -UserGroup "CN=CRM01UserGroup,OU=CRM groups,DC=uplift,DC=local" `
-    -ReportingGroup "CN=CRM01ReportingGroup,OU=CRM groups,DC=uplift,DC=local" `
-    -PrivReportingGroup "CN=CRM01PrivReportingGroup,OU=CRM groups,DC=uplift,DC=local" `
-    -CrmServiceAccount $CRMServiceAccountCredential `
-    -DeploymentServiceAccount $DeploymentServiceAccountCredential `
-    -SandboxServiceAccount $SandboxServiceAccountCredential `
-    -VSSWriterServiceAccount $VSSWriterServiceAccountCredential `
-    -AsyncServiceAccount $AsyncServiceAccountCredential `
-    -MonitoringServiceAccount $MonitoringServiceAccountCredential `
-    -CreateWebSite `
-    -WebSitePort 5555 `
-    -WebSiteUrl "https://$computerName.uplift.local" `
-    -Organization "Uplift Ltd." `
-    -OrganizationUniqueName uplift `
-    -BaseISOCurrencyCode USD `
-    -BaseCurrencyName "US Dollar" `
-    -BaseCurrencySymbol `$ `
-    -BaseCurrencyPrecision 2 `
-    -OrganizationCollation Latin1_General_CI_AI `
-    -ReportingUrl ("http://" + $computerName + ":80/ReportServer") `
-    -InstallAccount $CRMInstallAccountCredential
+if($crmModuleVersion -gt $pullLogMinVersion) {
+    Write-UpliftMessage  "Using -LogFilePullToOutput option"
+
+    Install-Dynamics365Server `
+        -MediaDir $mediaDir `
+        -LicenseKey $licenceKey `
+        -InstallDir "c:\Program Files\Microsoft Dynamics CRM" `
+        -CreateDatabase `
+        -SqlServer $dbHostName `
+        -PrivUserGroup "CN=CRM01PrivUserGroup,OU=CRM groups,DC=uplift,DC=local" `
+        -SQLAccessGroup "CN=CRM01SQLAccessGroup,OU=CRM groups,DC=uplift,DC=local" `
+        -UserGroup "CN=CRM01UserGroup,OU=CRM groups,DC=uplift,DC=local" `
+        -ReportingGroup "CN=CRM01ReportingGroup,OU=CRM groups,DC=uplift,DC=local" `
+        -PrivReportingGroup "CN=CRM01PrivReportingGroup,OU=CRM groups,DC=uplift,DC=local" `
+        -CrmServiceAccount $CRMServiceAccountCredential `
+        -DeploymentServiceAccount $DeploymentServiceAccountCredential `
+        -SandboxServiceAccount $SandboxServiceAccountCredential `
+        -VSSWriterServiceAccount $VSSWriterServiceAccountCredential `
+        -AsyncServiceAccount $AsyncServiceAccountCredential `
+        -MonitoringServiceAccount $MonitoringServiceAccountCredential `
+        -CreateWebSite `
+        -WebSitePort 5555 `
+        -WebSiteUrl "https://$computerName.uplift.local" `
+        -Organization "Uplift Ltd." `
+        -OrganizationUniqueName uplift `
+        -BaseISOCurrencyCode USD `
+        -BaseCurrencyName "US Dollar" `
+        -BaseCurrencySymbol `$ `
+        -BaseCurrencyPrecision 2 `
+        -OrganizationCollation Latin1_General_CI_AI `
+        -ReportingUrl ("http://" + $computerName + ":80/ReportServer") `
+        -InstallAccount $CRMInstallAccountCredential `
+        -LogFilePullToOutput
+} else {
+    Write-UpliftMessage  "Skipping -LogFilePullToOutput option, v1.0.0.0 module or older"
+
+    Install-Dynamics365Server `
+        -MediaDir $mediaDir `
+        -LicenseKey $licenceKey `
+        -InstallDir "c:\Program Files\Microsoft Dynamics CRM" `
+        -CreateDatabase `
+        -SqlServer $dbHostName `
+        -PrivUserGroup "CN=CRM01PrivUserGroup,OU=CRM groups,DC=uplift,DC=local" `
+        -SQLAccessGroup "CN=CRM01SQLAccessGroup,OU=CRM groups,DC=uplift,DC=local" `
+        -UserGroup "CN=CRM01UserGroup,OU=CRM groups,DC=uplift,DC=local" `
+        -ReportingGroup "CN=CRM01ReportingGroup,OU=CRM groups,DC=uplift,DC=local" `
+        -PrivReportingGroup "CN=CRM01PrivReportingGroup,OU=CRM groups,DC=uplift,DC=local" `
+        -CrmServiceAccount $CRMServiceAccountCredential `
+        -DeploymentServiceAccount $DeploymentServiceAccountCredential `
+        -SandboxServiceAccount $SandboxServiceAccountCredential `
+        -VSSWriterServiceAccount $VSSWriterServiceAccountCredential `
+        -AsyncServiceAccount $AsyncServiceAccountCredential `
+        -MonitoringServiceAccount $MonitoringServiceAccountCredential `
+        -CreateWebSite `
+        -WebSitePort 5555 `
+        -WebSiteUrl "https://$computerName.uplift.local" `
+        -Organization "Uplift Ltd." `
+        -OrganizationUniqueName uplift `
+        -BaseISOCurrencyCode USD `
+        -BaseCurrencyName "US Dollar" `
+        -BaseCurrencySymbol `$ `
+        -BaseCurrencyPrecision 2 `
+        -OrganizationCollation Latin1_General_CI_AI `
+        -ReportingUrl ("http://" + $computerName + ":80/ReportServer") `
+        -InstallAccount $CRMInstallAccountCredential 
+}
+
+exit 0

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-ps-modules.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-ps-modules.ps1
@@ -1,0 +1,30 @@
+# fail on errors and include uplift helpers
+$ErrorActionPreference = "Stop"
+
+Import-Module Uplift.Core
+
+Write-UpliftMessage "Configuring CRM PowerShell modules"
+Write-UpliftEnv
+
+# - install other DSC packages
+$packages = @(
+
+    @{ 
+        Id = "InvokeUplift" 
+    },
+
+    @{ 
+        Id = "Dynamics365Configuration"
+    },
+
+    @{ 
+        Id = "CertificateDsc"
+        Version = "4.1.0.0"
+    }
+     
+)
+
+Write-UpliftMessage "Installing DSC modules: $packages"
+Install-UpliftPSModules $packages
+
+exit 0

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-ps-modules.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-ps-modules.ps1
@@ -10,11 +10,8 @@ Write-UpliftEnv
 $packages = @(
 
     @{ 
-        Id = "InvokeUplift" 
-    },
-
-    @{ 
         Id = "Dynamics365Configuration"
+        Version = "1.0"
     },
 
     @{ 

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-sql-accounts.dsc.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-sql-accounts.dsc.ps1
@@ -1,0 +1,106 @@
+# fail on errors and include uplift helpers
+$ErrorActionPreference = "Stop"
+
+Import-Module Uplift.Core
+
+Write-UpliftMessage "Configring SQL accounts for CRM..."
+Write-UpliftEnv
+
+Configuration Configure_CRM_SQLUsers {
+
+    Import-DscResource -ModuleName PSDesiredStateConfiguration
+
+    Import-DscResource -ModuleName SqlServerDsc -ModuleVersion 12.2.0.0
+
+    Node localhost
+    {
+        $computerName = $env:COMPUTERNAME
+        $instanceName = 'MSSQLSERVER'
+
+        $adminsGroup  = "BUILTIN\Administrators";
+
+        $domainAdminCreds = New-Object System.Management.Automation.PSCredential(
+            "uplift\vagrant", 
+             (ConvertTo-SecureString "vagrant" -AsPlainText -Force)
+        )
+
+        SqlServerLogin Add_AdministratorsGroup
+        {
+            Ensure               = 'Present'
+
+            Name                 =  $adminsGroup
+            LoginType            = 'WindowsGroup'
+            
+            ServerName           = $computerName
+            InstanceName         = $instanceName
+            
+            PsDscRunAsCredential = $domainAdminCreds
+        }
+
+        SqlServerRole Grant_AdministratorsGroup_Db_Creator
+        {
+            Ensure               = 'Present'
+            ServerRoleName       = 'db_creator'
+            MembersToInclude     = $adminsGroup
+            
+            ServerName           = $computerName
+            InstanceName         = $instanceName
+            
+            PsDscRunAsCredential = $domainAdminCreds
+
+            DependsOn = @(
+                '[SqlServerLogin]Add_AdministratorsGroup'
+            )
+        }
+
+        SqlServerRole Grant_AdministratorsGroup_SecurityAdmin
+        {
+            Ensure               = 'Present'
+            ServerRoleName       = 'securityadmin'
+            MembersToInclude     = $adminsGroup
+            
+            ServerName           = $computerName
+            InstanceName         = $instanceName
+            
+            PsDscRunAsCredential = $domainAdminCreds
+
+            DependsOn = @(
+                '[SqlServerLogin]Add_AdministratorsGroup'
+            )
+        }
+
+        SqlServerRole Grant_AdministratorsGroup_SysAdmin
+        {
+            Ensure               = 'Present'
+            ServerRoleName       = 'sysadmin'
+            MembersToInclude     = $adminsGroup
+            
+            ServerName           = $computerName
+            InstanceName         = $instanceName
+            
+            PsDscRunAsCredential = $domainAdminCreds
+
+            DependsOn = @(
+                '[SqlServerLogin]Add_AdministratorsGroup'
+            )
+        }
+    }
+}
+
+$config = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+            PSDscAllowPlainTextPassword = $true
+            PSDscAllowDomainUser = $true
+            
+            RetryCount = 10           
+            RetryIntervalSec = 30
+        }
+    )
+}
+
+$configuration = Get-Command Configure_CRM_SQLUsers
+Start-UpliftDSCConfiguration $configuration $config $True
+
+exit 0

--- a/uplift-vagrant/crm-dev/scripts-crm/crm-ssl-self-signed-cert.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/crm-ssl-self-signed-cert.ps1
@@ -1,0 +1,25 @@
+
+# fail on errors and include uplift helpers
+$ErrorActionPreference = "Stop"
+
+Import-Module Uplift.Core
+
+Write-UpliftMessage "Creating self-signed cert for CRM..."
+Write-UpliftEnv
+
+$certPassword = "asd94y3475n";
+
+$pfxPass = ConvertTo-SecureString $certPassword -AsPlainText -Force;
+New-Item c:\certs -ItemType Directory
+@(
+    "$env:COMPUTERNAME.uplift.local"
+) | % {
+    $hostName = $_;
+
+    $cert = New-SelfSignedCertificate -DnsName $hostName -CertStoreLocation Cert:\LocalMachine\My;
+    
+    $cert | Export-PfxCertificate -FilePath "c:\certs\$hostName.pfx" -Password $pfxPass -Force | Out-Null;
+    $cert | Remove-Item -Force;
+}
+
+exit 0

--- a/uplift-vagrant/crm-dev/scripts-crm/sql-rs-config.ps1
+++ b/uplift-vagrant/crm-dev/scripts-crm/sql-rs-config.ps1
@@ -1,0 +1,46 @@
+# fail on errors and include uplift helpers
+$ErrorActionPreference = "Stop"
+
+Import-Module Uplift.Core
+
+Write-UpliftMessage "Running RS config..."
+Write-UpliftEnv
+
+Configuration Configure_SqlRS {
+
+    Import-DscResource -ModuleName SqlServerDsc -ModuleVersion 11.1.0.0
+
+    Node localhost
+    {
+        SqlRS ReportingServicesConfig
+        {
+            InstanceName                 = 'MSSQLSERVER'
+            DatabaseServerName           = 'localhost'
+            DatabaseInstanceName         = 'MSSQLSERVER'
+
+            #ReportServerVirtualDirectory = 'MyReportServer'
+            
+            ReportServerReservedUrl      = @( 'http://+:80' )
+            
+            #ReportsVirtualDirectory      = 'MyReports'
+            #ReportsReservedUrl           = @( 'http://+:80', 'https://+:443' )
+            #UseSsl                       = $true
+        }
+    }
+}
+
+$config = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+            PSDscAllowPlainTextPassword = $true
+            RetryCount = 10
+            RetryIntervalSec = 30
+        }
+    )
+}
+
+$configuration = Get-Command Configure_SqlRS
+Start-UpliftDSCConfiguration $configuration $config
+
+exit 0

--- a/uplift-vagrant/crm-dev/scripts-dc/crm-domain-users.ps1
+++ b/uplift-vagrant/crm-dev/scripts-dc/crm-domain-users.ps1
@@ -1,0 +1,206 @@
+# fail on errors and include $simpleDomainName helpers
+$ErrorActionPreference = "Stop"
+
+Import-Module Uplift.Core
+
+Write-UpliftMessage "Configuring DC with CRM specific settings"
+Write-UpliftEnv
+
+$domainName = "uplift"
+
+$securedPassword = ConvertTo-SecureString "c0mp1Expa~~" -AsPlainText -Force
+$SqlRSAccountCredential = New-Object System.Management.Automation.PSCredential( "$domainName\_ssrs", $securedPassword );
+$CRMInstallAccountCredential = New-Object System.Management.Automation.PSCredential( "$domainName\_crmadmin", $securedPassword );
+$CRMServiceAccountCredential = New-Object System.Management.Automation.PSCredential( "$domainName\_crmsrv", $securedPassword );
+$DeploymentServiceAccountCredential = New-Object System.Management.Automation.PSCredential( "$domainName\_crmdplsrv", $securedPassword );
+$SandboxServiceAccountCredential = New-Object System.Management.Automation.PSCredential( "$domainName\_crmsandbox", $securedPassword );
+$VSSWriterServiceAccountCredential = New-Object System.Management.Automation.PSCredential( "$domainName\_crmvsswrit", $securedPassword );
+$AsyncServiceAccountCredential = New-Object System.Management.Automation.PSCredential( "$domainName\_crmasync", $securedPassword );
+$MonitoringServiceAccountCredential = New-Object System.Management.Automation.PSCredential( "$domainName\_crmmon", $securedPassword );
+
+Configuration ConfigureDomainForCRM
+{
+    Import-DscResource -ModuleName PSDesiredStateConfiguration
+    Import-DscResource -ModuleName xActiveDirectory -ModuleVersion 2.21.0.0
+
+    Node localhost
+    {
+        $domainName = $Node.DomainName
+        $simpleDomainName = $domainName.Split('.')[0]
+
+        $SqlRSAccountCredential = $Node.SqlRSAccountCredential
+        $CRMInstallAccountCredential = $Node.CRMInstallAccountCredential
+        $CRMServiceAccountCredential = $Node.CRMServiceAccountCredential
+        $DeploymentServiceAccountCredential = $Node.DeploymentServiceAccountCredential
+        $SandboxServiceAccountCredential = $Node.SandboxServiceAccountCredential
+        $VSSWriterServiceAccountCredential = $Node.VSSWriterServiceAccountCredential
+        $AsyncServiceAccountCredential = $Node.AsyncServiceAccountCredential
+        $MonitoringServiceAccountCredential = $Node.MonitoringServiceAccountCredential
+
+        xADUser SqlRSAccountCredentialUser
+        {
+            DomainName              = $domainName
+            UserName                = $SqlRSAccountCredential.GetNetworkCredential().UserName
+            Password                = $SqlRSAccountCredential
+            PasswordNeverExpires    = $true
+        }
+        
+        xADUser CRMInstallAccountUser
+        {
+            DomainName              = $domainName
+            UserName                = $CRMInstallAccountCredential.GetNetworkCredential().UserName
+            Password                = $CRMInstallAccountCredential
+            PasswordNeverExpires    = $true
+        }
+        
+        xADUser CRMServiceAccountUser
+        {
+            DomainName              = $domainName
+            UserName                = $CRMServiceAccountCredential.GetNetworkCredential().UserName
+            Password                = $CRMServiceAccountCredential
+            PasswordNeverExpires    = $true
+        }
+
+        xADUser DeploymentServiceAccountUser
+        {
+            DomainName              = $domainName
+            UserName                = $DeploymentServiceAccountCredential.GetNetworkCredential().UserName
+            Password                = $DeploymentServiceAccountCredential
+            PasswordNeverExpires    = $true
+        }
+
+        xADUser SandboxServiceAccountUser
+        {
+            DomainName              = $domainName
+            UserName                = $SandboxServiceAccountCredential.GetNetworkCredential().UserName
+            Password                = $SandboxServiceAccountCredential
+            PasswordNeverExpires    = $true
+        }
+
+        xADUser VSSWriterServiceAccountUser
+        {
+            DomainName              = $domainName
+            UserName                = $VSSWriterServiceAccountCredential.GetNetworkCredential().UserName
+            Password                = $VSSWriterServiceAccountCredential
+            PasswordNeverExpires    = $true
+        }
+
+        xADUser AsyncServiceAccountUser
+        {
+            DomainName              = $domainName
+            UserName                = $AsyncServiceAccountCredential.GetNetworkCredential().UserName
+            Password                = $AsyncServiceAccountCredential
+            PasswordNeverExpires    = $true
+        }
+
+        xADUser MonitoringServiceAccountUser
+        {
+            DomainName              = $domainName
+            UserName                = $MonitoringServiceAccountCredential.GetNetworkCredential().UserName
+            Password                = $MonitoringServiceAccountCredential
+            PasswordNeverExpires    = $true
+        }
+
+        xADOrganizationalUnit CRMGroupsOU
+        {
+           Name = "CRM groups"
+           Path = "DC=$simpleDomainName,DC=local"
+        }
+
+        xADGroup CRMPrivUserGroup
+        {
+            GroupName           = "CRM01PrivUserGroup"
+            MembersToInclude    = $CRMInstallAccountCredential.GetNetworkCredential().UserName
+            GroupScope          = "Universal"
+            Path                = "OU=CRM groups,DC=$simpleDomainName,DC=local"
+            DependsOn           = "[xADUser]CRMInstallAccountUser"
+        }
+        
+        xADObjectPermissionEntry OUPermissions
+        {
+            Ensure                              = 'Present'
+            Path                                = "OU=CRM groups,DC=$simpleDomainName,DC=local"
+            IdentityReference                   = "$simpleDomainName\CRM01PrivUserGroup"
+            ActiveDirectoryRights               = 'GenericAll'
+            AccessControlType                   = 'Allow'
+            ObjectType                          = '00000000-0000-0000-0000-000000000000'
+            ActiveDirectorySecurityInheritance  = 'All'
+            InheritedObjectType                 = '00000000-0000-0000-0000-000000000000'
+            DependsOn                           = "[xADGroup]CRMPrivUserGroup"
+        }
+    
+        xADGroup CRMSQLAccessGroup
+        {
+            GroupName   = "CRM01SQLAccessGroup"
+            GroupScope  = "Universal"
+            Path        = "OU=CRM groups,DC=$simpleDomainName,DC=local"
+        }
+
+        xADGroup CRMUserGroup
+        {
+            GroupName   = "CRM01UserGroup"
+            Path        = "OU=CRM groups,DC=$simpleDomainName,DC=local"
+        }
+
+        xADGroup CRMReportingGroup
+        {
+            GroupName   = "CRM01ReportingGroup"
+            GroupScope  = "Universal"
+            Path        = "OU=CRM groups,DC=$simpleDomainName,DC=local"
+        }
+
+        xADGroup CRMPrivReportingGroup
+        {
+            GroupName           = "CRM01PrivReportingGroup"
+            MembersToInclude    = $SqlRSAccountCredential.GetNetworkCredential().UserName
+            GroupScope          = "Universal"
+            Path                = "OU=CRM groups,DC=$simpleDomainName,DC=local"
+        }
+
+        xADGroup EnterpriseAdminGroup
+        {
+            GroupName   = "Enterprise Admins"
+            MembersToInclude    = $CRMInstallAccountCredential.GetNetworkCredential().UserName
+        }
+
+        xADGroup DomainAdminGroup
+        {
+            GroupName   = "Domain Admins"
+            MembersToInclude    = $CRMInstallAccountCredential.GetNetworkCredential().UserName
+        }
+
+        xADGroup Administrators
+        {
+            GroupName   = "Administrators"
+            MembersToInclude    = $CRMInstallAccountCredential.GetNetworkCredential().UserName
+        }
+
+    }
+}
+
+$config = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+            PSDscAllowPlainTextPassword = $true
+            RetryCount = 10
+            RetryIntervalSec = 30
+
+            DomainName = "uplift.local"
+
+            SqlRSAccountCredential = $SqlRSAccountCredential 
+            CRMInstallAccountCredential = $CRMInstallAccountCredential 
+            CRMServiceAccountCredential = $CRMServiceAccountCredential 
+            DeploymentServiceAccountCredential = $DeploymentServiceAccountCredential 
+            SandboxServiceAccountCredential = $SandboxServiceAccountCredential 
+            VSSWriterServiceAccountCredential = $VSSWriterServiceAccountCredential 
+            AsyncServiceAccountCredential = $AsyncServiceAccountCredential 
+            MonitoringServiceAccountCredential = $MonitoringServiceAccountCredential
+        }
+    )
+}
+
+$configuration = Get-Command ConfigureDomainForCRM
+Start-UpliftDSCConfiguration $configuration $config $True
+
+exit 0

--- a/uplift-vagrant/crm-dev/scripts-dc/crm-ps-modules.ps1
+++ b/uplift-vagrant/crm-dev/scripts-dc/crm-ps-modules.ps1
@@ -1,0 +1,23 @@
+# fail on errors and include uplift helpers
+$ErrorActionPreference = "Stop"
+
+Import-Module Uplift.Core
+
+Write-UpliftMessage "Installing PowerShell Modules..."
+Write-UpliftEnv
+
+# https://github.com/shurick81/vm-devops-starter/blob/dev/infrastructure/images/basepsmodules.ps1
+# adpsmodules.ps1"
+
+$packages = @(
+
+    @{ 
+        Id = "xActiveDirectory";       
+        Version = "2.21.0.0" 
+    }
+)
+
+Write-UpliftMessage "Installing DSC modules: $packages"
+Install-UpliftPSModules $packages
+
+exit 0

--- a/uplift-vagrant/sp16lts-dev-spmeta2/Vagrantfile
+++ b/uplift-vagrant/sp16lts-dev-spmeta2/Vagrantfile
@@ -7,12 +7,14 @@ box_name       =  ENV['UPLF_VAGRANT_BOX_NAME']       || "SubPointSolutions/win-2
 linked_clone   =  ENV['UPLF_VAGRANT_LINKED_CLONE'].to_s.empty? == false
 machine_folder =  ENV['UPLF_VBMANAGE_MACHINEFOLDER'] || nil
 
+vm_client16_public_ip =  ENV['UPLF_SP16LTS_PUBLIC_IP'] || nil
+
 # two vm topology: dc and client 
 # - dc box gets promoted to minimal domain controller
 # - client box gets SQL server completion and then setups minimal SharePoint farm
 
-vm_dc     = "dc"
-vm_client = "sp16lts"
+vm_dc       = "dc"
+vm_client16 = "sp16lts"
 
 # this configuration is driven by the ENV variables
 # use the following variables to change default RAM/CPU allocation
@@ -82,11 +84,10 @@ Vagrant.configure("2") do |config|
     # -- UPLIFT CONFIG END --
     # add your custom vagrant configuration here
 
-
   end  
 
   # dev box - sql/sp/vs 
-  config.vm.define "#{vm_client}" do | vm_config |   
+  config.vm.define(vm_client16) do | vm_config |   
     
     # -- UPLIFT CONFIG START --
     # there should not be a need to modify core uplift configration
@@ -97,75 +98,76 @@ Vagrant.configure("2") do |config|
     vm_config.vm.box_check_update = false
 
     # uplift - base config
-    uplift.set_default_synced_folder(vm_client, vm_config)
-    uplift.set_6Gb(vm_client, vm_config)
-    uplift.set_hostname(vm_client, vm_config, vm_client)   
+    uplift.set_default_synced_folder(vm_client16, vm_config)
+    uplift.set_6Gb(vm_client16, vm_config)
+    uplift.set_hostname(vm_client16, vm_config, vm_client16)   
 
     # uplift - network, base provision + dc join
-    uplift.set_client_network(vm_client, vm_config, vm_client)
+    uplift.set_client_network(vm_client16, vm_config, vm_client16)
+    uplift.set_public_network(vm_client16, vm_config, vm_client16_public_ip)
 
-    if !uplift.has_checkpoint?(vm_client, 'dsc-soe') 
-      uplift.provision_win16_dsc_soe(vm_client, vm_config)
+    if !uplift.has_checkpoint?(vm_client16, 'dsc-soe') 
+      uplift.provision_win16_dsc_soe(vm_client16, vm_config)
       vm_config.vm.provision :uplift_checkpoint, name: 'dsc-soe'
     end
 
-    if !uplift.has_checkpoint?(vm_client, 'dc-join') 
-      uplift.provision_dc_join(vm_client, vm_config)
+    if !uplift.has_checkpoint?(vm_client16, 'dc-join') 
+      uplift.provision_dc_join(vm_client16, vm_config)
       vm_config.vm.provision :uplift_checkpoint, name: 'dc-join'
     end
 
-    if !uplift.has_checkpoint?(vm_client, 'dsc-shortcuts') 
-      uplift.provision_win16_dsc_shortcuts(vm_client, vm_config)
+    if !uplift.has_checkpoint?(vm_client16, 'dsc-shortcuts') 
+      uplift.provision_win16_dsc_shortcuts(vm_client16, vm_config)
       vm_config.vm.provision :uplift_checkpoint, name: 'dsc-shortcuts'
     end
 
-    # we use sql on the same
-    # uplift.provision_sp16_single_server_farm() points to SQL server name, last param - vm_client
+    # we use sql on the same box
+    # uplift.provision_sp16_single_server_farm() points to SQL server name, last param - vm_client16
 
     # complete sql image
-    if !uplift.has_checkpoint?(vm_client, 'sql-complete-image') 
-        uplift.provision_sql16_complete_image(vm_client, vm_config)
+    if !uplift.has_checkpoint?(vm_client16, 'sql-complete-image') 
+        uplift.provision_sql16_complete_image(vm_client16, vm_config)
         vm_config.vm.provision :uplift_checkpoint, name: 'sql-complete-image'
     end
 
-    if !uplift.has_checkpoint?(vm_client, 'sql16-optimize') 
-      uplift.provision_sql16_optimize(vm_client, vm_config)
+    if !uplift.has_checkpoint?(vm_client16, 'sql16-optimize') 
+      uplift.provision_sql16_optimize(vm_client16, vm_config)
       vm_config.vm.provision :uplift_checkpoint, name: 'sql16-optimize'
     end
 
     # complete sharepoint install
-    if !uplift.has_checkpoint?(vm_client, 'sp-farm-presetup') 
-      uplift.provision_sp16_pre_setup(vm_client, vm_config)
+    if !uplift.has_checkpoint?(vm_client16, 'sp-farm-presetup') 
+      uplift.provision_sp16_pre_setup(vm_client16, vm_config)
       vm_config.vm.provision :uplift_checkpoint, name: 'sp-farm-presetup'
     end
 
-    if !uplift.has_checkpoint?(vm_client, 'sp-accounts') 
-      uplift.provision_sp16_sp_accounts(vm_client, vm_config)
+    if !uplift.has_checkpoint?(vm_client16, 'sp-accounts') 
+      uplift.provision_sp16_sp_accounts(vm_client16, vm_config)
       vm_config.vm.provision :uplift_checkpoint, name: 'sp-accounts'
     end
 
-    if !uplift.has_checkpoint?(vm_client, 'sp-sql-accounts') 
-      uplift.provision_sp16_sql_accounts(vm_client, vm_config)
+    if !uplift.has_checkpoint?(vm_client16, 'sp-sql-accounts') 
+      uplift.provision_sp16_sql_accounts(vm_client16, vm_config)
       vm_config.vm.provision :uplift_checkpoint, name: 'sp-sql-accounts'
     end
 
-    if !uplift.has_checkpoint?(vm_client, 'sp-single-farm') 
-      uplift.provision_sp16_single_server_farm(vm_client, vm_config, vm_client)
+    if !uplift.has_checkpoint?(vm_client16, 'sp-single-farm') 
+      uplift.provision_sp16_single_server_farm(vm_client16, vm_config, vm_client16)
       vm_config.vm.provision :uplift_checkpoint, name: 'sp-single-farm'
     end
 
-    if !uplift.has_checkpoint?(vm_client, 'sp-farm-services') 
-      uplift.provision_sp16_minimal_services(vm_client, vm_config, vm_client)
+    if !uplift.has_checkpoint?(vm_client16, 'sp-farm-services') 
+      uplift.provision_sp16_minimal_services(vm_client16, vm_config, vm_client16)
       vm_config.vm.provision :uplift_checkpoint, name: 'sp-farm-services'
     end
     
-    if !uplift.has_checkpoint?(vm_client, 'sp-farm-post-setup') 
-      uplift.provision_sp16_farm_post_setup(vm_client, vm_config)
+    if !uplift.has_checkpoint?(vm_client16, 'sp-farm-post-setup') 
+      uplift.provision_sp16_farm_post_setup(vm_client16, vm_config)
       vm_config.vm.provision :uplift_checkpoint, name: 'sp-farm-post-setup'
     end
 
-    if !uplift.has_checkpoint?(vm_client, 'sp-web-app') 
-      uplift.provision_sp16_web_application(vm_client, vm_config)
+    if !uplift.has_checkpoint?(vm_client16, 'sp-web-app') 
+      uplift.provision_sp16_web_application(vm_client16, vm_config)
       vm_config.vm.provision :uplift_checkpoint, name: 'sp-web-app'
     end
 
@@ -173,8 +175,8 @@ Vagrant.configure("2") do |config|
     vm_config.vm.provider "virtualbox" do |v|
       v.gui  = false
       
-      v.cpus   = uplift.get_vm_cpus(vm_client, 4)
-      v.memory = uplift.get_vm_memory(vm_client, 6 * 1024)
+      v.cpus   = uplift.get_vm_cpus(vm_client16, 4)
+      v.memory = uplift.get_vm_memory(vm_client16, 6 * 1024)
 
       v.customize ['modifyvm', :id, '--cpuexecutioncap', '100'] 
       v.customize ["modifyvm", :id, "--ioapic", "on"]


### PR DESCRIPTION
Added vagrant configs for minimal CRM installation.

Work is based on @shurick81 work:
* https://github.com/shurick81/Dynamics365Configuration
* https://github.com/shurick81/sp-devops-starters

Standard two VMs config with dc and crm boxes. This particular config requires file resource to be served and SQL SP2 as a minimal base line (required by CRM). 

Vagrant config installs pre-CRM packages and configs, a bit messy scripting, and then two web sites on `443` and `5555` for https/http.

Testing pipeline is also added into Jenkins server:
* https://github.com/SubPointSolutions/uplift-cicd-jenkins2