### PR TITLE
+ added single dc16 example 

### DIFF
--- a/uplift-vagrant/dc16/Vagrantfile
+++ b/uplift-vagrant/dc16/Vagrantfile
@@ -1,0 +1,80 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.require_version ">= 2.2.3"
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+
+# variables:
+# - box name to be used
+# - virtual machine name and hostname
+# - linked_clone usage (https://www.vagrantup.com/docs/virtualbox/configuration.html#linked-clones)
+
+box_name       =  ENV['UPLF_VAGRANT_BOX_NAME']       || "SubPointSolutions/win-2016-datacenter-app"
+linked_clone   =  ENV['UPLF_VAGRANT_LINKED_CLONE'].to_s.empty? == false
+machine_folder =  ENV['UPLF_VBMANAGE_MACHINEFOLDER'] || nil
+
+vm_dc  = "dc"
+
+# uplift helper for vagrant configurations
+uplift = VagrantPlugins::Uplift::Config()
+
+Vagrant.configure("2") do |config|
+  
+  config.vm.define(vm_dc) do | vm_config |      
+
+    # -- UPLIFT CONFIG START --
+    # there should not be a need to modify core uplift configration
+    # avoid making changes to it, add your own provision at the end
+
+    vm_config.vm.box = box_name
+
+    # standard config
+    uplift.set_default_synced_folder(vm_dc, vm_config)
+    uplift.set_2Gb(vm_dc, vm_config)
+    uplift.set_hostname(vm_dc, vm_config, vm_dc)
+    
+    # always setup correct networking
+    uplift.set_private_dc_network(vm_dc, vm_config)
+    
+    # uplift baseline
+    if !uplift.has_checkpoint?(vm_dc, 'dsc-soe') 
+      uplift.provision_win16_dsc_soe(vm_dc, vm_config)
+      vm_config.vm.provision :uplift_checkpoint, name: 'dsc-soe'
+    end
+
+    # uplift dc creation
+    if !uplift.has_checkpoint?(vm_dc, 'dc-creation') 
+      uplift.provision_dc16(vm_dc, vm_config)
+      vm_config.vm.provision :uplift_checkpoint, name: 'dc-creation'
+    end
+
+    # common shortcuts on the desktop
+    if !uplift.has_checkpoint?(vm_dc, 'dsc-shortcuts') 
+      uplift.provision_win16_dsc_shortcuts(vm_dc, vm_config)
+      vm_config.vm.provision :uplift_checkpoint, name: 'dsc-shortcuts'
+    end
+
+    # additional virtualbox tweaks
+    vm_config.vm.provider "virtualbox" do |v|
+      v.gui  = false
+     
+      v.cpus   = uplift.get_vm_cpus(vm_dc, 4)
+      v.memory = uplift.get_vm_memory(vm_dc, 2 * 1024)
+
+      v.customize ['modifyvm', :id, '--cpuexecutioncap', '100'] 
+      v.customize ["modifyvm", :id, "--ioapic", "on"]
+
+      v.linked_clone = linked_clone
+    end
+
+    # -- UPLIFT CONFIG END --
+    
+    # add your custom vagrant configuration here
+
+  end  
+
+end


### PR DESCRIPTION
Added single dc16 example:
* [Generated packer templates doesn't work with packer 1.3.5](https://github.com/SubPointSolutions/uplift-packer/issues/9) cc @616b2f 
* [Building a disposable Windows 2016 domain controller in 20 minutes with Vagrant](https://medium.com/@SubPointSocial/building-a-disposable-windows-2016-domain-controller-in-20-minutes-with-vagrant-fce6eb4e01bd)